### PR TITLE
Fix cleanup after the oslo.messaging tests

### DIFF
--- a/start-coverage.sh
+++ b/start-coverage.sh
@@ -620,6 +620,7 @@ function oslo.messaging_controller_stop {
 	ssh root@node-$1 '''
         OSLO_MESSAGING_INIT=`python -c "import oslo.messaging; print oslo.messaging.__file__" | sed s/.pyc$/.py/`
         mv ${OSLO_MESSAGING_INIT}.bkp ${OSLO_MESSAGING_INIT}
+        rm ${OSLO_MESSAGING_INIT}c # remove .pyc file
         sudo reboot
 	'''
     # Check, that node is up and receive ssh connection
@@ -644,6 +645,7 @@ function oslo.messaging_compute_stop {
 	ssh root@node-$1 '''
         OSLO_MESSAGING_INIT=`python -c "import oslo.messaging; print oslo.messaging.__file__" | sed s/.pyc$/.py/`
         mv ${OSLO_MESSAGING_INIT}.bkp ${OSLO_MESSAGING_INIT}
+        rm ${OSLO_MESSAGING_INIT}c # remove .pyc file
         sudo reboot
 	'''
     # Check, that node is up and receive ssh connection


### PR DESCRIPTION
When oslo.messaging coverage tests are finished, a _.pyc file with patched
code stays in the codebase, so it can be used instead of `clean`_.py file 
and cause a lot of issues during the future measurement.

This patch removes *.pyc file.
